### PR TITLE
Use multi-stage Docker build for Linux target

### DIFF
--- a/docker/opensearch/docker-compose.yml
+++ b/docker/opensearch/docker-compose.yml
@@ -47,7 +47,7 @@ services:
   cloud-speed-runner:
     build:
       context: ../..
-      dockerfile: docker/runner/Dockerfile.prebuilt
+      dockerfile: docker/runner/Dockerfile
     container_name: cloud-speed-runner
     environment:
       - OPENSEARCH_URL=http://opensearch:9200

--- a/docker/runner/Dockerfile
+++ b/docker/runner/Dockerfile
@@ -1,3 +1,20 @@
+# Build stage - compile for Linux target
+FROM rust:1.85-bookworm AS builder
+
+# Install git for build.rs (captures git hash for version string)
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy source code (including .git for version hash)
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src ./src
+COPY .git ./.git
+
+# Build optimized release binary
+RUN cargo build --profile release-lto
+
+# Runtime stage - minimal image
 FROM debian:bookworm-slim
 
 # Install runtime dependencies
@@ -7,8 +24,8 @@ RUN apt-get update && apt-get install -y \
     cron \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy pre-built binary (build with: cargo build --profile release-lto)
-COPY target/release-lto/cloud-speed /usr/local/bin/cloud-speed
+# Copy the built binary from builder stage
+COPY --from=builder /app/target/release-lto/cloud-speed /usr/local/bin/cloud-speed
 
 # Copy runner script and cron config
 COPY docker/runner/run-speedtest.sh /usr/local/bin/run-speedtest.sh


### PR DESCRIPTION
Replace pre-built binary approach with multi-stage build that compiles the binary inside the container for the correct Linux target architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)