### PR TITLE
Fix 0.0 Mbps for downloads >= 10MB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cloud-speed"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloud-speed"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 authors = ["Hunter Skrasek"]
 description = """

--- a/src/cloudflare/tests/connection.rs
+++ b/src/cloudflare/tests/connection.rs
@@ -79,7 +79,7 @@ pub async fn tls_handshake_duration(
             let now = Instant::now();
 
             let mut stream = connector.connect(&host, tcp)?;
-            stream.flush().expect("Stream error");
+            stream.flush()?;
             let tls_handshake_duration = now.elapsed();
             Ok((
                 Box::new(stream) as Box<dyn IoReadAndWrite>,

--- a/src/cloudflare/tests/connection.rs
+++ b/src/cloudflare/tests/connection.rs
@@ -40,54 +40,80 @@ pub async fn resolve_dns(url: &Url) -> Result<(IpAddr, Duration), Box<dyn Error>
 
 /// Establish a TCP connection to the given address and port.
 ///
+/// Runs on a blocking thread pool via `spawn_blocking` to avoid
+/// starving the tokio async runtime.
+///
 /// Returns the connected stream and the time taken to establish the connection.
-pub fn tcp_connect(
+pub async fn tcp_connect(
     address: IpAddr,
     port: u16,
 ) -> Result<(TcpStream, Duration), Box<dyn Error>> {
-    let now = Instant::now();
-    let mut stream = TcpStream::connect((address, port))?;
-    stream.flush()?;
-    let tcp_connect_duration = now.elapsed();
-
-    Ok((stream, tcp_connect_duration))
+    tokio::task::spawn_blocking(move || {
+        let now = Instant::now();
+        let mut stream = TcpStream::connect((address, port))?;
+        stream.flush()?;
+        let tcp_connect_duration = now.elapsed();
+        Ok::<_, std::io::Error>((stream, tcp_connect_duration))
+    })
+    .await?
+    .map_err(|e| e.into())
 }
 
 /// Perform TLS handshake on an established TCP connection.
 ///
+/// Runs on a blocking thread pool via `spawn_blocking` to avoid
+/// starving the tokio async runtime.
+///
 /// Returns a TLS-wrapped stream and the time taken for the handshake.
-pub fn tls_handshake_duration(
+pub async fn tls_handshake_duration(
     tcp: TcpStream,
-    url: &Url,
+    host: String,
 ) -> Result<(Box<dyn IoReadAndWrite>, Duration), Box<dyn Error>> {
-    let connector: RustlsConnector = RustlsConnector::new_with_native_certs()
-        .unwrap_or_else(|_| RustlsConnector::new_with_webpki_roots_certs());
-    let now = Instant::now();
+    let result: Result<_, Box<dyn Error + Send + Sync>> =
+        tokio::task::spawn_blocking(move || {
+            let connector: RustlsConnector =
+                RustlsConnector::new_with_native_certs()
+                    .unwrap_or_else(|_| {
+                        RustlsConnector::new_with_webpki_roots_certs()
+                    });
+            let now = Instant::now();
 
-    let certificate_host = url.host_str().unwrap_or("");
-    let mut stream = connector.connect(certificate_host, tcp)?;
-    stream.flush().expect("Stream error");
-    let tls_handshake_duration = now.elapsed();
-    Ok((Box::new(stream), tls_handshake_duration))
+            let mut stream = connector.connect(&host, tcp)?;
+            stream.flush().expect("Stream error");
+            let tls_handshake_duration = now.elapsed();
+            Ok((
+                Box::new(stream) as Box<dyn IoReadAndWrite>,
+                tls_handshake_duration,
+            ))
+        })
+        .await?;
+
+    result.map_err(|e| e as Box<dyn Error>)
 }
 
 /// Measure TCP latency by performing a TCP handshake.
 ///
+/// Runs on a blocking thread pool via `spawn_blocking` to avoid
+/// starving the tokio async runtime.
+///
 /// This is used for loaded latency measurements during bandwidth tests.
 /// Returns the round-trip time in milliseconds.
-pub fn measure_tcp_latency(
+pub async fn measure_tcp_latency(
     ip_address: IpAddr,
     port: u16,
 ) -> Result<f64, Box<dyn Error + Send + Sync>> {
-    let start = Instant::now();
-    let stream = TcpStream::connect_timeout(
-        &std::net::SocketAddr::new(ip_address, port),
-        Duration::from_secs(5),
-    )?;
-    let latency = start.elapsed();
+    tokio::task::spawn_blocking(move || {
+        let start = Instant::now();
+        let stream = TcpStream::connect_timeout(
+            &std::net::SocketAddr::new(ip_address, port),
+            Duration::from_secs(5),
+        )?;
+        let latency = start.elapsed();
 
-    // Close the connection
-    drop(stream);
+        // Close the connection
+        drop(stream);
 
-    Ok(latency.as_secs_f64() * 1000.0)
+        Ok(latency.as_secs_f64() * 1000.0)
+    })
+    .await?
 }

--- a/src/cloudflare/tests/download.rs
+++ b/src/cloudflare/tests/download.rs
@@ -143,7 +143,8 @@ async fn execute_http_get(
             .map_err(|e| format!("Invalid UTF-8 in HTTP headers: {}", e))?;
 
         // Check HTTP status code before processing body
-        let status = extract_http_status(&headers_str).unwrap_or(0);
+        let status = extract_http_status(&headers_str)
+            .ok_or("Malformed HTTP response from speed test server")?;
         if status != 200 {
             return Err(format!("HTTP {status} from speed test server").into());
         }
@@ -305,7 +306,8 @@ async fn execute_http_get_with_latency(
             .map_err(|e| format!("Invalid UTF-8 in HTTP headers: {}", e))?;
 
         // Check HTTP status code before processing body
-        let status = extract_http_status(&headers_str).unwrap_or(0);
+        let status = extract_http_status(&headers_str)
+            .ok_or("Malformed HTTP response from speed test server")?;
         if status != 200 {
             return Err(format!("HTTP {status} from speed test server").into());
         }

--- a/src/cloudflare/tests/mod.rs
+++ b/src/cloudflare/tests/mod.rs
@@ -11,6 +11,17 @@ pub(crate) mod upload;
 
 pub(crate) static BASE_URL: &str = "https://speed.cloudflare.com";
 
+/// Extract HTTP status code from a raw HTTP response status line.
+///
+/// Parses "HTTP/1.1 200 OK\r\n..." and returns the numeric status code.
+pub(crate) fn extract_http_status(raw_headers: &str) -> Option<u16> {
+    raw_headers
+        .lines()
+        .next()
+        .and_then(|status_line| status_line.split_whitespace().nth(1))
+        .and_then(|code| code.parse().ok())
+}
+
 pub trait IoReadAndWrite: Read + Write + Send {}
 
 impl<T: Read + Write + Send> IoReadAndWrite for T {}

--- a/src/cloudflare/tests/mod.rs
+++ b/src/cloudflare/tests/mod.rs
@@ -11,9 +11,9 @@ pub(crate) mod upload;
 
 pub(crate) static BASE_URL: &str = "https://speed.cloudflare.com";
 
-pub trait IoReadAndWrite: Read + Write {}
+pub trait IoReadAndWrite: Read + Write + Send {}
 
-impl<T: Read + Write> IoReadAndWrite for T {}
+impl<T: Read + Write + Send> IoReadAndWrite for T {}
 
 pub(crate) trait Test {
     fn endpoint(&'_ self) -> Cow<'_, str>;


### PR DESCRIPTION
## Summary

- **Root cause:** Blocking `std::io::Read::read_to_end()` on `rustls_connector::TlsStream<TcpStream>` inside async functions starved the tokio runtime for 10MB+ downloads, causing truncated/empty responses and 0.0 Mbps measurements
- **Fix:** All blocking TCP connect, TLS handshake, and HTTP read/write operations now run on dedicated thread pools via `tokio::task::spawn_blocking`, keeping async worker threads free for concurrent latency measurement tasks
- **Additional:** `Accept-Encoding: identity` prevents compressed responses from confusing byte-level reads

## Changes

| File | What changed |
|------|-------------|
| `src/cloudflare/tests/connection.rs` | `tcp_connect`, `tls_handshake_duration`, `measure_tcp_latency` wrapped in `spawn_blocking` |
| `src/cloudflare/tests/download.rs` | `execute_http_get` and `execute_http_get_with_latency` use `spawn_blocking` for all I/O |
| `src/cloudflare/tests/upload.rs` | `execute_http_post` and `execute_http_post_with_latency` use `spawn_blocking` for all I/O |
| `src/cloudflare/tests/mod.rs` | Added `Send` bound to `IoReadAndWrite` trait (required for `spawn_blocking`) |
| `Cargo.toml` | Version bump to 0.8.3 |

## Test plan

- [x] All 228 existing unit tests pass
- [ ] Manual test: run `cloud-speed` and verify 10MB+ downloads report non-zero Mbps
- [ ] Manual test: run `cloud-speed --json` and verify all bandwidth measurements are populated

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)